### PR TITLE
Added error handling (unauthorized) from okta

### DIFF
--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -362,6 +362,15 @@ func CallbackHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	errorState := r.URL.Query().Get("error")
+	if errorState != "" {
+		errorDescription := r.URL.Query().Get("error_description")
+		log.Warning("Error state: ", errorState, ", Error description: ", errorDescription)
+		w.WriteHeader(http.StatusForbidden)
+		renderIndex(w, "FORBIDDEN: " + errorDescription)
+		return
+	}
+
 	user := structs.User{}
 	if err := getUserInfo(r, &user); err != nil {
 		log.Error(err)


### PR DESCRIPTION
This must be done before trying to get the user,
otherwise the app yields an 400 error:
```
oauth2: cannot fetch token: 400 Bad Request
Response: {"error":"invalid_grant","error_description":"The authorization code is invalid or has expired."}
```